### PR TITLE
rename rotate_toward to quaternion_rotate_toward

### DIFF
--- a/Godot-Human-For-Scale/Assets/HumanController.gd
+++ b/Godot-Human-For-Scale/Assets/HumanController.gd
@@ -173,8 +173,8 @@ func _unhandled_input(event):
 			KEY_ESCAPE:
 				mousecapture_isdown = event.pressed
 
-static func rotate_toward(from: Quaternion, to: Quaternion, delta: float) -> Quaternion:
+static func quaternion_rotate_toward(from: Quaternion, to: Quaternion, delta: float) -> Quaternion:
 	return from.slerp(to, clamp(delta / from.angle_to(to), 0.0, 1.0)).normalized()
 
 static func basis_rotate_toward(from: Basis, to: Basis, delta: float) -> Basis:
-	return Basis(rotate_toward(from.get_rotation_quaternion(), to.get_rotation_quaternion(), delta)).orthonormalized()
+	return Basis(quaternion_rotate_toward(from.get_rotation_quaternion(), to.get_rotation_quaternion(), delta)).orthonormalized()


### PR DESCRIPTION
In Godot 4.2 rotate_toward was added as GlobalScope, the function definition in Godot-Human-For-Scale/Assets/HumanController.gd collided with this new definition.

Tested in Godot 4.2 beta 2.